### PR TITLE
Add Cocoapods support

### DIFF
--- a/STUtils.podspec
+++ b/STUtils.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "STUtils"
+  s.version      = "0.0.1"
+  s.summary      = "Various useful Objective-C code."
+  s.homepage     = "https://github.com/ldandersen/STUtils.git"
+  s.license      = "MIT"
+  s.authors      = { 'Buzz Andersen' => 'buzz@scifihifi.com' }
+
+  s.source       = { :git => "https://github.com/ldandersen/STUtils.git", :commit => "3389fb68605514afe0f14dd712e7d51ca0cfb054" }
+
+  s.subspec 'Additions' do |ios|  
+    ios.source_files = "iOS/**/*"
+  end
+
+  s.subspec 'Security' do |security|
+    security.source_files = "Security"
+    security.frameworks = "Security"
+  end
+end


### PR DESCRIPTION
I added a spec for cocoapods, as your repo does not contain tag (yet) I cannot push it to Cocoapods for other.For now it points to a (old) commit `3389fb68605514afe0f14dd712e7d51ca0cfb054 "making the STUtils Keychainwrapper standalone"`

Hope to see Cocoapods support soon, let me know if you need any help in that
